### PR TITLE
make /var/lib/ociregistry owned by nonroot:nonroot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ COPY api/ ./api/
 COPY cmd/ ./cmd/
 COPY impl/ ./impl/
 
+# make a dir we know is empty
+RUN mkdir /var/lib/emptydir
+
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build\
     -ldflags "-X 'main.buildVer=v$SERVER_VERSION' -X 'main.buildDtm=$DATETIME'" -a -o server cmd/*.go
 
@@ -18,6 +21,8 @@ FROM gcr.io/distroless/static:nonroot
 
 WORKDIR /ociregistry
 COPY --from=build /app/server .
+# copy emptydir with correct permissions for mounted volume to inherit
+COPY --from=build --chown=nonroot:nonroot /var/lib/emptycir /var/lib/ociregistry
 USER nonroot:nonroot
 
 ENTRYPOINT ["/ociregistry/server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM gcr.io/distroless/static:nonroot
 WORKDIR /ociregistry
 COPY --from=build /app/server .
 # copy emptydir with correct permissions for mounted volume to inherit
-COPY --from=build --chown=nonroot:nonroot /var/lib/emptycir /var/lib/ociregistry
+COPY --from=build --chown=nonroot:nonroot /var/lib/emptydir /var/lib/ociregistry
 USER nonroot:nonroot
 
 ENTRYPOINT ["/ociregistry/server"]


### PR DESCRIPTION
We are running the quay.io image with docker-compose.  We had to mount our registry volume under /home/nonroot (and pass a command-line option in to point at that) in order for it to have the right permissions to be written to by the nonroot user.  This change creates an empty directory in the build stage and then copies it with correct permissions into /var/lib/ociregistry in the nonroot final image (since it's not possible to create a directory with RUN).  This will allow mounting a volume at the default path and not needing to specify --image-path (not only on the running process, but also when executing server commands like --list-cache)