### PR TITLE
Add support for chunked downloads

### DIFF
--- a/impl/handlers.go
+++ b/impl/handlers.go
@@ -1,9 +1,12 @@
 package impl
 
 import (
+	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/aceeric/ociregistry/api/models"
 	"github.com/aceeric/ociregistry/impl/cache"
@@ -53,13 +56,122 @@ func (r *OciRegistry) handleV2GetOrgImageBlobsDigest(ctx echo.Context, org strin
 		log.Errorf("blob not on the file system for org %q, image %q, digest %q", org, image, digest)
 		return ctx.JSON(http.StatusInternalServerError, "")
 	}
-	ctx.Response().Header().Add("Content-Length", strconv.Itoa(int(fi.Size())))
-	ctx.Response().Header().Add("Docker-Distribution-Api-Version", "registry/2.0")
+
 	f, err := os.Open(blob_file)
 	if err != nil {
 		return err
 	}
-	return ctx.Stream(http.StatusOK, "binary/octet-stream", f)
+	defer f.Close()
+
+	fileSize := fi.Size()
+
+	// Check for Range header
+	rangeHeader := ctx.Request().Header.Get("Range")
+	if rangeHeader == "" {
+		// No Range header - serve entire file
+		ctx.Response().Header().Add("Content-Length", strconv.FormatInt(fileSize, 10))
+		ctx.Response().Header().Add("Docker-Distribution-Api-Version", "registry/2.0")
+		ctx.Response().Header().Add("Accept-Ranges", "bytes")
+		return ctx.Stream(http.StatusOK, "binary/octet-stream", f)
+	}
+
+	// Parse Range header (format: "bytes=start-end")
+	start, end, err := parseRangeHeader(rangeHeader, fileSize)
+	if err != nil {
+		log.Warnf("invalid Range header %q for digest %q: %v", rangeHeader, digest, err)
+		ctx.Response().Header().Add("Content-Range", fmt.Sprintf("bytes */%d", fileSize))
+		return ctx.NoContent(http.StatusRequestedRangeNotSatisfiable)
+	}
+
+	// Seek to start position
+	_, err = f.Seek(start, io.SeekStart)
+	if err != nil {
+		log.Errorf("failed to seek to position %d for digest %q: %v", start, digest, err)
+		return ctx.JSON(http.StatusInternalServerError, "")
+	}
+
+	// Calculate content length for this range
+	contentLength := end - start + 1
+
+	// Set response headers for partial content
+	ctx.Response().Header().Add("Content-Length", strconv.FormatInt(contentLength, 10))
+	ctx.Response().Header().Add("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, fileSize))
+	ctx.Response().Header().Add("Docker-Distribution-Api-Version", "registry/2.0")
+	ctx.Response().Header().Add("Accept-Ranges", "bytes")
+
+	// Stream the requested range
+	return ctx.Stream(http.StatusPartialContent, "binary/octet-stream", io.LimitReader(f, contentLength))
+}
+
+// parseRangeHeader parses an HTTP Range header and returns start and end positions.
+// Returns an error if the range is invalid or unsatisfiable.
+func parseRangeHeader(rangeHeader string, fileSize int64) (start, end int64, err error) {
+	// Expected format: "bytes=start-end" or "bytes=start-" or "bytes=-suffix"
+	if !strings.HasPrefix(rangeHeader, "bytes=") {
+		return 0, 0, fmt.Errorf("range header must start with 'bytes='")
+	}
+
+	rangeSpec := strings.TrimPrefix(rangeHeader, "bytes=")
+
+	// Handle multiple ranges (we only support single range)
+	if strings.Contains(rangeSpec, ",") {
+		return 0, 0, fmt.Errorf("multiple ranges not supported")
+	}
+
+	parts := strings.Split(rangeSpec, "-")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid range format")
+	}
+
+	startStr := strings.TrimSpace(parts[0])
+	endStr := strings.TrimSpace(parts[1])
+
+	if startStr == "" && endStr == "" {
+		return 0, 0, fmt.Errorf("both start and end cannot be empty")
+	}
+
+	if startStr == "" {
+		// Suffix range: "bytes=-500" means last 500 bytes
+		suffix, err := strconv.ParseInt(endStr, 10, 64)
+		if err != nil || suffix <= 0 {
+			return 0, 0, fmt.Errorf("invalid suffix length")
+		}
+		if suffix > fileSize {
+			suffix = fileSize
+		}
+		return fileSize - suffix, fileSize - 1, nil
+	}
+
+	start, err = strconv.ParseInt(startStr, 10, 64)
+	if err != nil || start < 0 {
+		return 0, 0, fmt.Errorf("invalid start position")
+	}
+
+	if endStr == "" {
+		// Open-ended range: "bytes=100-" means from byte 100 to end
+		end = fileSize - 1
+	} else {
+		end, err = strconv.ParseInt(endStr, 10, 64)
+		if err != nil || end < 0 {
+			return 0, 0, fmt.Errorf("invalid end position")
+		}
+	}
+
+	// Validate range
+	if start > end {
+		return 0, 0, fmt.Errorf("start position %d is greater than end position %d", start, end)
+	}
+
+	if start >= fileSize {
+		return 0, 0, fmt.Errorf("start position %d is beyond file size %d", start, fileSize)
+	}
+
+	// Adjust end if it's beyond file size
+	if end >= fileSize {
+		end = fileSize - 1
+	}
+
+	return start, end, nil
 }
 
 // GET /v2/


### PR DESCRIPTION
Add support for chunked downloads of image blobs with `Range:` header

A fair warning, this is entirely vibe coded with claud as it is a bit above my head.
Solves:
https://github.com/aceeric/ociregistry/issues/18