### PR TITLE
Add hard memory request/limit to stop page cache buildup

### DIFF
--- a/charts/ociregistry/values.yaml
+++ b/charts/ociregistry/values.yaml
@@ -114,7 +114,11 @@ ingress:
 # time. Volumetrics are forthcoming in a future release. If I run the server as a systemd
 # service and inspect it with the "glances" utility, glances reports 11 meg of resident
 # RAM with no images cached, and 14 meg of resident RAM with 60 images cached...
-resources: {}
+resources: 
+  requests:
+    memory: "128Mi"
+  limits:
+    memory: "128Mi"
 
 # -- Use this to mount other volumes.
 volumes: []


### PR DESCRIPTION
Hello again!

I have digged into a memory "issue" I have had while running ociregistry in my test environment where k8s reports ocregistry is using alot of memory and memory usage growing indefinitely until restart of the pod.

As ociregistry is quite IO intensive it hits [this](https://github.com/kubernetes/kubernetes/issues/43916) feature/bug.
Its quite the read.

In my test environment with about 10 nodes the ociregistry service doesnt actually use more than 20 MB of memory (If I check the metrics spanning 7 days back) but kubernetes reports way more(4GB is my max).
The bad part is what kubernetes reports is what the deployment will reserve on the node meaning the ociregistry deployment pods will eventually reserve so much memory that other pods wont schedule on the same node if running without memory limit/request set.


Its a annoying problem and as far as I know(And I have search alot for other workarounds) its not fixable in any other way then setting a hard request/limit.

This setting in the PR I have had for about a week on my environment without any problem or OOM terminations.

Its easy to set by yourself for users but I though it would be good idea to have this by default in your chart to avoid any future reports on memory usage by users of the ociregistry helm chart.